### PR TITLE
Hardcoded paths to certificates

### DIFF
--- a/lib/puppet/functions/nodegroups.rb
+++ b/lib/puppet/functions/nodegroups.rb
@@ -2,12 +2,20 @@ require 'json'
 
 Puppet::Functions.create_function(:nodegroups) do
   dispatch :nodegroups do
-    required_param 'String', :puppet_data
+    required_param 'String', :pe_server
     optional_param 'String', :node_name
   end
 
-  def nodegroups(puppet_data, node_name = '')
-    puppet_settings = JSON.parse(puppet_data)
+  def nodegroups(pe_server, node_name = '')
+    puppet_settings = {
+      'confdir'     => '/etc/puppetlabs/puppet',
+      'certname'    => pe_server,
+      'server'      => pe_server,
+      'localcacert' => '/etc/puppetlabs/puppet/ssl/certs/ca.pem',
+      'hostcert'    => "/etc/puppetlabs/orchestration-services/ssl/#{pe_server}.cert.pem",
+      'hostprivkey' => "/etc/puppetlabs/orchestration-services/ssl/#{pe_server}.private_key.pem",
+    }
+
     settings_file = "#{puppet_settings['confdir']}/classifier.yaml"
 
     begin


### PR DESCRIPTION
Must use PE Orchestration Services certificate as a PE Plan runs in that context.

Use in a plan like this:
```
plan testplan(
  String $pe_server     # Provide certname of the PE master here
) {
  $result = nodegroups($pe_server, 'PE Master')      # Example for the "PE Master" node group
  out::message("Node Group 'PE Master' ID: ${result['PE Master']['id']}")
  out::message("Node Group 'PE Master' parent ID: ${result['PE Master']['parent']}")
}
```